### PR TITLE
Use the complete plugin signature

### DIFF
--- a/src/index.es
+++ b/src/index.es
@@ -1,5 +1,5 @@
 export default (options) => {
-  return files => {
+  return (files, metalsmith, done) => {
     Object.keys(files).forEach(filename => {
       let newName = filename
       options.forEach(replacement => {
@@ -10,5 +10,6 @@ export default (options) => {
         delete files[filename]
       }
     })
+    done()
   }
 }


### PR DESCRIPTION
Expect `metalsmith` and `done` as arguments and call `done()` when file renaming is done.

Rationale: with the latest metalsmith, using this plugin (along with metalsmith-branch) results in nothing being output. I figured that calling `done()` fixes the issue.
